### PR TITLE
Bookings bugfix

### DIFF
--- a/juntagrico_billing/test/test_base.py
+++ b/juntagrico_billing/test/test_base.py
@@ -1,0 +1,127 @@
+import django.test
+from datetime import date
+from juntagrico.entity.subs import *
+from juntagrico.entity.extrasubs import *
+from juntagrico.entity.subtypes import *
+from juntagrico.entity.billing import *
+from juntagrico.entity.member import Member
+from juntagrico_billing.entity.settings import Settings
+from juntagrico_billing.entity.account import MemberAccount
+
+class SubscriptionTestBase(django.test.TestCase):
+    def setUp(self):
+        subs_product = SubscriptionProduct.objects.create(
+            name = "Test-Product",
+            description = "Test-Product Description"
+        )
+
+        subs_size = SubscriptionSize.objects.create(
+            name = "Normal",
+            long_name = "Normale Grösse",
+            units = 1,
+            product = subs_product
+            )
+
+        self.subs_type = SubscriptionType.objects.create(
+            name="Normal",
+            size = subs_size,
+            shares = 1,
+            required_assignments = 5,
+            price = 1200,
+            )
+
+        self.depot = Depot.objects.create(
+            code = "Depot 1",
+            name = "Das erste Depot",
+            contact = self.create_member("Test", "Depot"),
+            weekday = 5,
+            )
+
+        self.subscription = self.create_subscription_and_member(self.subs_type, date(2018, 1, 1), None,
+                                                                "Michael", "Test", "4321")
+
+        extrasub_category = ExtraSubscriptionCategory.objects.create(
+            name = "ExtraCat1"
+            )
+
+        extrasub_type = ExtraSubscriptionType.objects.create(
+            name = "Extra 1",
+            size = "Extragross",
+            description = "Extra Subscription",
+            category = extrasub_category
+            )
+
+        extrasub_period1 = ExtraSubBillingPeriod.objects.create(
+            type = extrasub_type,
+            price = 100,
+            start_day = 1,
+            start_month = 1,
+            end_day = 30,
+            end_month = 6,
+            cancel_day = 31,
+            cancel_month = 5
+            )
+        extrasub_period2 = ExtraSubBillingPeriod.objects.create(
+            type = extrasub_type,
+            price = 200,
+            start_day = 1,
+            start_month = 7,
+            end_day = 31,
+            end_month = 12,
+            cancel_day = 30,
+            cancel_month = 11
+            )
+
+        self.extrasubs = ExtraSubscription.objects.create(
+            main_subscription = self.subscription,
+            active = True,
+            activation_date = date(2018,1,1),
+            type = extrasub_type
+            )
+
+        Settings.objects.create(
+            debtor_account = "1100"
+            )
+
+    def create_member(self, first_name, last_name):
+        member = Member.objects.create(
+            first_name = first_name,
+            last_name = last_name,
+            email = "%s@%s.ch" % (last_name, last_name),
+            addr_street = "Musterstrasse",
+            addr_zipcode = "8000",
+            addr_location = "Zürich",
+            phone = "01234567"
+            )
+        member.save()
+        return member
+
+    def create_subscription_and_member(self, type, activation_date, deactivation_date, first_name, last_name, account):
+        member = self.create_member(first_name, last_name)
+        subscription = Subscription.objects.create(
+            depot = self.depot,
+            active = True,
+            activation_date = activation_date,
+            deactivation_date = deactivation_date
+            )
+        member.subscription = subscription
+        member.save()
+        subscription.primary_member = member
+        subscription.save()
+
+        tsst = TSST.objects.create(
+            subscription = subscription,
+            type = type
+            )
+        tsst.save()
+
+         # create account for member
+        MemberAccount.objects.create(
+            member = member,
+            account = account
+            )
+
+        return subscription
+
+
+

--- a/juntagrico_billing/test/test_bills.py
+++ b/juntagrico_billing/test/test_bills.py
@@ -1,8 +1,8 @@
 from datetime import date
 from django.conf import settings
 
-from test.util.subscription_test_base import SubscriptionTestBase
-from juntagrico.util.bills import scale_subscription_price
+from juntagrico_billing.test.test_base import SubscriptionTestBase
+from juntagrico_billing.util.bills import scale_subscription_price
 
 
 class ScaleSuscriptionPriceTest(SubscriptionTestBase):

--- a/juntagrico_billing/test/test_bookings.py
+++ b/juntagrico_billing/test/test_bookings.py
@@ -46,6 +46,30 @@ class SubscriptionBookingsTest(SubscriptionTestBase):
         self.assertEqual(docnumber_expected, docnumber, "document_number for subscription")
 
 
+    def test_inactive_subscription(self):
+        # subscription was deactivated before our interval
+        self.subscription.active = False
+        self.subscription.deactivation_date = date(2017, 12, 31)
+        self.subscription.save()
+
+        start_date = date(2018, 1, 1)
+        end_date = date(2018, 12, 31)
+        bookings_list = subscription_bookings_by_date(start_date, end_date)
+        self.assertEqual(0, len(bookings_list))
+
+
+    def test_neveractive_subscription(self):
+        # subscription was never activated
+        self.subscription.active = False
+        self.subscription.activation_date = None
+        self.subscription.save()
+
+        start_date = date(2018, 1, 1)
+        end_date = date(2018, 12, 31)
+        bookings_list = subscription_bookings_by_date(start_date, end_date)
+        self.assertEqual(0, len(bookings_list))
+
+
 class ExtraSubscriptionBookingsTest(SubscriptionTestBase):
 
     def test_generate_document_number_for_extra_subscription(self):
@@ -161,3 +185,17 @@ class ExtraSubscriptionBookingsTest(SubscriptionTestBase):
         self.assertEqual("", booking.credit_account)
         self.assertEqual("4321", booking.member_account)
         self.assertEqual("Zusatz: Extra 1, 01.07.18-30.11.18, Michael Test", booking.text)
+
+
+    def test_inactive_primary_suscription(self):
+        # deactivate primary subscription, extra subscription should not
+        # get a booking, even if still active itself
+        self.subscription.active = False
+        self.subscription.deactivation_date = date(2017, 12, 31)
+        self.subscription.save()
+
+        start_date = date(2018, 1, 1)
+        end_date = date(2018, 12, 31)
+        bookings_list = extrasub_bookings_by_date(start_date, end_date)
+        self.assertEqual(0, len(bookings_list))
+

--- a/manage.py
+++ b/manage.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python
+import os
+import sys
+
+from django.core.management import execute_from_command_line
+
+if __name__ == "__main__":
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "testsettings")
+    execute_from_command_line(sys.argv)


### PR DESCRIPTION
Small bugfixes for current bookings export:
* suppress booking when the main subscription of an extra subscription is inactive
* suppress booking when a subscription has never been active

Moved unit tests into sub-package of juntagrico_billing.