### PR TITLE
bugfix in send_bill_notifications

### DIFF
--- a/juntagrico_billing/mailer.py
+++ b/juntagrico_billing/mailer.py
@@ -36,4 +36,4 @@ def send_bill_notification(bill):
     content = plaintext.render(base_dict(locals()))
     subject = organisation_subject(_('{0} Bill').format(Config.vocabulary('subscription')))
 
-    EmailSender.get_sender(content, subject).send_to(member.email)
+    EmailSender.get_sender(subject, content).send_to(member.email)


### PR DESCRIPTION
Small bugfix for sending billing notifications.
The arguments for subject and content were in the wrong order. 
Couldn't test the actual e-mail sending.