### PR TITLE
prevent error in bill.ordered_items

### DIFF
--- a/juntagrico_billing/entity/bill.py
+++ b/juntagrico_billing/entity/bill.py
@@ -93,7 +93,8 @@ class Bill(JuntagricoBaseModel):
             elif itm.custom_item_type:
                 return (2, itm.custom_item_type.id, itm.id)
             else:
-                return (3)
+                # itm without reference (unexpected)
+                return (3, None)
 
         return sorted(self.items.all(), key=order_key)
 


### PR DESCRIPTION
fixed small error in `bill.ordered_items`. 
the error "'<' not supported between instances of 'int' and 'tuple'" appeared when a bill contained an item that had no reference to a subscription part or custom-type. 
this case should normally not occur.