### PR TITLE
Fix digits of precision for QR Bill

### DIFF
--- a/juntagrico_billing/util/qrbill.py
+++ b/juntagrico_billing/util/qrbill.py
@@ -84,7 +84,7 @@ def get_qrbill_svg(bill, paymenttype):
         account=stdnum.iban.compact(paymenttype.iban),
         reference_number=refnr,
         additional_information=info,
-        amount=Decimal(bill.amount_open),
+        amount=Decimal(str(bill.amount_open)),
         creditor={
             'name': addr['name'],
             'line1': '%s %s' % (addr['street'], addr['number']),

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 -e .
 coverage>=7.4.0
 ruff>=0.2.0
+python-bidi<0.5.0


### PR DESCRIPTION
For QR bill, round amount to two digits. Alternative to #44

Please review and release as 1.6.2

close https://github.com/juntagrico/juntagrico-billing/issues/43