### PR TITLE
Support negative amounts in booking lists

### DIFF
--- a/juntagrico_billing/tests/test_billbookings.py
+++ b/juntagrico_billing/tests/test_billbookings.py
@@ -102,6 +102,7 @@ class BillBookingsTest(BillingTestCase):
         self.assertEquals('1010', booking.credit_account)
         self.assertEquals('4321', booking.member_account)
 
+
 class BillWithCustomItemBookingsTest(BillingTestCase):
     def test_get_bill_bookings(self):
         item_type1 = BillItemType(name='Custom Item 1', booking_account='2211')

--- a/juntagrico_billing/tests/test_billbookings.py
+++ b/juntagrico_billing/tests/test_billbookings.py
@@ -80,6 +80,27 @@ class BillBookingsTest(BillingTestCase):
         self.assertEquals('1010', booking.debit_account)
         self.assertEquals('4321', booking.member_account)
 
+    def test_negative_payment_bookings(self):
+        """
+        test negative payment bookings
+
+        booking amount should always be positive
+        and credit and debit account should be exchanged
+        """
+        self.payment1.amount = -500.0
+        self.payment1.save()
+
+        bookings = get_payment_bookings(self.year.start_date, self.year.end_date)
+
+        self.assertEquals(2, len(bookings))
+        booking = bookings[0]
+        self.assertEquals(date(2018, 2, 1), booking.date)
+        self.assertEquals('600001', booking.docnumber)
+        self.assertEquals("Zlg Rg 1: Abo, Zusatzabo Michael Test", booking.text)
+        self.assertEquals(500.0, booking.price)
+        self.assertEquals('1100', booking.debit_account)
+        self.assertEquals('1010', booking.credit_account)
+        self.assertEquals('4321', booking.member_account)
 
 class BillWithCustomItemBookingsTest(BillingTestCase):
     def test_get_bill_bookings(self):

--- a/juntagrico_billing/util/bookings.py
+++ b/juntagrico_billing/util/bookings.py
@@ -83,7 +83,6 @@ def get_payment_bookings(fromdate, tilldate):
         bookings.append(booking)
 
         booking.date = payment.paid_date
-        booking.credit_account = debtor_account
 
         # docnumber is DOCNUMBER_OFFSET_PAYMENT + of bill*10 + sequence number of bill item
         booking.docnumber = str(DOCNUMBER_OFFSET_PAYMENT + payment.id)
@@ -91,9 +90,17 @@ def get_payment_bookings(fromdate, tilldate):
         bill = payment.bill
         # 'Pmt' and 'Bl' are short forms for payment and bill
         booking.text = "%s %s %d: %s %s" % (_('Pmt'), _('Bl'), bill.id, bill.item_kinds, bill.member)
-        # todo where to get bank account from?
-        booking.debit_account = payment.type.booking_account
-        booking.price = payment.amount
+
+        if payment.amount >= 0:
+            booking.price = payment.amount
+            booking.debit_account = payment.type.booking_account
+            booking.credit_account = debtor_account
+        else:
+            # negative amount: exchange accounts and set positive amount
+            booking.price = -payment.amount
+            booking.debit_account = debtor_account
+            booking.credit_account = payment.type.booking_account
+
         if hasattr(payment.bill.member, "member_account"):
             booking.member_account = payment.bill.member.member_account.account
         else:


### PR DESCRIPTION
Our accounting software (banana accounting) doesn't like negative amounts on bookings.
Need to swap booking accounts on negative amounts and make sure amount is always positive or 0.
This is already implemented for invoice bookings (bills), this PR adds the same for payment bookings.