### PR TITLE
Fix pdf bill for zero sum bills

### DIFF
--- a/juntagrico_billing/tests/__init__.py
+++ b/juntagrico_billing/tests/__init__.py
@@ -5,6 +5,7 @@ from juntagrico.tests import JuntagricoTestCase
 
 from juntagrico_billing.models.account import SubscriptionTypeAccount, MemberAccount
 from juntagrico_billing.models.bill import BusinessYear
+from juntagrico_billing.models.payment import PaymentType
 from juntagrico_billing.models.settings import Settings
 
 
@@ -22,6 +23,9 @@ class BillingTestCase(JuntagricoTestCase):
         cls.sub_type.price = 1200
         cls.sub_type.name = 'Normal'
         cls.sub_type.save()
+        cls.sub_type3.price = -1200
+        cls.sub_type3.name = 'Negative'
+        cls.sub_type3.save()
 
         cls.extrasub_type.name = 'Extra 1'
         cls.extrasub_type.save()
@@ -64,8 +68,14 @@ class BillingTestCase(JuntagricoTestCase):
             cancel_month=11
         )
 
+        # create payment type and settings
+        cls.payment_type = PaymentType.objects.create(
+            name='Test payment type',
+            iban='CH85009969813949107J7'
+        )
         cls.settings = Settings.objects.create(
-            debtor_account="1100"
+            debtor_account="1100",
+            default_paymenttype=cls.payment_type,
         )
 
     @staticmethod

--- a/juntagrico_billing/tests/test_bills.py
+++ b/juntagrico_billing/tests/test_bills.py
@@ -6,7 +6,6 @@ import django.core.mail
 from juntagrico.entity.subs import SubscriptionPart
 
 from juntagrico_billing.models.bill import Bill, BillItem, BillItemType
-from juntagrico_billing.models.payment import PaymentType
 from juntagrico_billing.util.billing import get_billable_subscription_parts, \
     create_bill, create_bills_for_items, recalc_bill, publish_bills
 from juntagrico_billing.util.billing import scale_subscriptionpart_price
@@ -404,15 +403,6 @@ class BillTest(BillingTestCase):
         )
         item.save()
         cls.bill.save()
-
-        # create payment type and settings
-        cls.payment_type = PaymentType.objects.create(
-            name='Test payment type',
-            iban=''
-        )
-        cls.payment_type.save()
-        cls.settings.default_paymenttype = cls.payment_type
-        cls.settings.save()
 
     def test_ordered_items(self):
         """

--- a/juntagrico_billing/tests/test_pdfbills.py
+++ b/juntagrico_billing/tests/test_pdfbills.py
@@ -1,0 +1,23 @@
+from datetime import date
+
+from django.http import HttpResponse
+from juntagrico.entity.subs import SubscriptionPart
+
+from juntagrico_billing.util.billing import create_bill
+from . import BillingTestCase
+from ..util.pdfbill import PdfBillRenderer
+
+
+class PdfBillTests(BillingTestCase):
+    def test_pdf_bill(self):
+        bill = create_bill(self.subscription.parts.all(), self.year, self.year.start_date)
+        PdfBillRenderer().render(bill, HttpResponse())
+
+    def test_zero_amount_pdf_bill(self):
+        self.extrasubs = SubscriptionPart.objects.create(
+            subscription=self.subscription,
+            activation_date=date(2018, 1, 1),
+            type=self.sub_type3
+        )
+        bill = create_bill(self.subscription.parts.all(), self.year, self.year.start_date)
+        PdfBillRenderer().render(bill, HttpResponse())

--- a/juntagrico_billing/util/pdfbill.py
+++ b/juntagrico_billing/util/pdfbill.py
@@ -213,11 +213,11 @@ class PdfBillRenderer(object):
                     '<b>%10.2f</b>' % (bill.amount - sum),
                     self.normalright)))
 
-        payments_table = Table(
-            lines, (4 * cm, None, 2 * cm),
-            style=self.table_style)
-
-        story.append(payments_table)
+        if lines:
+            payments_table = Table(
+                lines, (4 * cm, None, 2 * cm),
+                style=self.table_style)
+            story.append(payments_table)
 
         if bill.paid:
             story.append(Paragraph(_('Bill paid completely'), self.normal))


### PR DESCRIPTION
And add tests for pdf bills.

Bills that amount to 0, e.g. only consisting of free subscription parts, failed to generate the pdf bill, because there would be no lines in the table.