### PR TITLE
Fix/test: decimals and management views

### DIFF
--- a/.github/workflows/juntagrico-ci.yml
+++ b/.github/workflows/juntagrico-ci.yml
@@ -33,7 +33,7 @@ jobs:
         pip install --upgrade -r requirements.txt
     - name: ruff
       run: |
-        ruff check juntagrico_billing
+        ruff check --preview juntagrico_billing
     - name: run tests
       run: |
         python -m django makemigrations --noinput

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  # Ruff version.
+  rev: v0.14.6
+  hooks:
+    - id: ruff-check
+      args: [ --preview, --fix ]

--- a/juntagrico_billing/tests/__init__.py
+++ b/juntagrico_billing/tests/__init__.py
@@ -4,8 +4,8 @@ from juntagrico.entity.billing import BillingPeriod
 from juntagrico.tests import JuntagricoTestCase
 
 from juntagrico_billing.models.account import SubscriptionTypeAccount, MemberAccount
-from juntagrico_billing.models.bill import BusinessYear
-from juntagrico_billing.models.payment import PaymentType
+from juntagrico_billing.models.bill import BusinessYear, Bill, BillItem
+from juntagrico_billing.models.payment import PaymentType, Payment
 from juntagrico_billing.models.settings import Settings
 
 
@@ -14,6 +14,7 @@ class BillingTestCase(JuntagricoTestCase):
     def setUpTestData(cls):
         # load from fixtures
         cls.load_members()
+        cls.default_member = cls.member
         # setup other objects
         cls.set_up_depots()
         cls.set_up_sub_types()
@@ -116,3 +117,23 @@ class BillingTestCase(JuntagricoTestCase):
             end_date=date(year, 12, 31),
             name=str(year)
         )
+
+    @classmethod
+    def create_bill(cls, member, item_type, date, amount):
+        bill = Bill.objects.create(
+            business_year=cls.year, member=member, published=True,
+            bill_date=date, booking_date=date)
+        BillItem.objects.create(
+            bill=bill, custom_item_type=item_type,
+            amount=amount
+        )
+        bill.save()
+        return bill
+
+    @classmethod
+    def create_payment(cls, payment_type, bill, amount, date):
+        payment = Payment.objects.create(
+            bill=bill, amount=amount, paid_date=date, type=payment_type
+        )
+        payment.save()
+        return payment

--- a/juntagrico_billing/tests/test_management_lists.py
+++ b/juntagrico_billing/tests/test_management_lists.py
@@ -1,0 +1,65 @@
+from datetime import date
+
+from django.urls import reverse
+
+from . import BillingTestCase
+from ..models.bill import BillItemType
+
+
+class ManagementListTests(BillingTestCase):
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        # create some bills
+        cls.item_type1 = BillItemType.objects.create(name='Test Item Type', booking_account='2211')
+        cls.bill1 = cls.create_bill(cls.member2, cls.item_type1, date(2024, 10, 1), 1200)
+        cls.bill2 = cls.create_bill(cls.member2, cls.item_type1, date(2024, 11, 1), 1300)
+
+    def test_open_bills(self):
+        self.assertGet(reverse('jb:open-bills-list'), 302)
+        self.assertGet(reverse('jb:open-bills-list'), member=self.admin)
+
+    def test_pending_bills(self):
+        self.assertGet(reverse('jb:pending-bills-list'), 302)
+        self.assertGet(reverse('jb:pending-bills-list'), member=self.admin)
+
+    def test_unpublished_bills(self):
+        self.assertGet(reverse('jb:unpublished-bills-list'), 302)
+        self.assertGet(reverse('jb:unpublished-bills-list'), member=self.admin)
+
+    def test_bills_publish(self):
+        self.assertGet(reverse('jb:bills-publish'), 302)
+        self.assertGet(reverse('jb:bills-publish'), 405, member=self.admin)
+        self.assertPost(reverse('jb:bills-publish'), {'bill_ids': str(self.bill1.id)}, code=302, member=self.admin)
+
+    def test_bills_set_year(self):
+        self.assertGet(reverse('jb:bills-setyear'), 302)
+        self.assertPost(reverse('jb:bills-setyear'), {'year': 2017}, 302)
+        self.assertIsNone(self.client.session.get('bills_businessyear'))
+
+        self.assertGet(reverse('jb:bills-setyear'), 405, member=self.admin)
+        self.assertPost(reverse('jb:bills-setyear'), {'year': 2017}, 302, member=self.admin)
+        self.assertEqual(self.client.session.get('bills_businessyear'), '2017')
+
+    def test_bills_generate(self):
+        self.assertGet(reverse('jb:bills-generate'), 302)
+        self.assertPost(reverse('jb:bills-generate'), code=302)
+
+        self.client.force_login(self.admin.user)
+        session = self.client.session
+        session['bills_businessyear'] = '2018'
+        session.save()
+        self.assertGet(reverse('jb:bills-generate'), 405, member=self.admin)
+        self.assertPost(reverse('jb:bills-generate'), code=302, member=self.admin)
+
+    def test_bills_notify(self):
+        self.assertGet(reverse('jb:bills-notify'), 302)
+        self.assertGet(reverse('jb:bills-notify'), member=self.admin)
+
+    def test_bills_recalc(self):
+        self.assertGet(reverse('jb:bill-recalc', args=[1]) + '?next=.', 302)
+        self.assertGet(reverse('jb:bill-recalc', args=[1]) + '?next=.', 302, member=self.admin)
+
+    def test_accounting_summary(self):
+        self.assertGet(reverse('jb:accounting-summary'), 302)
+        self.assertGet(reverse('jb:accounting-summary'), member=self.admin)

--- a/juntagrico_billing/tests/test_memberbalance.py
+++ b/juntagrico_billing/tests/test_memberbalance.py
@@ -10,24 +10,6 @@ class MemberBalanceTest(BillingTestCase):
     def setUpTestData(cls):
         super().setUpTestData()
 
-        def create_bill(member, date, amount):
-            bill = Bill.objects.create(
-                business_year=cls.year, member=member, published=True,
-                bill_date=date, booking_date=date)
-            BillItem.objects.create(
-                bill=bill, custom_item_type=cls.item_type1,
-                amount=amount
-            )
-            bill.save()
-            return bill
-
-        def create_payment(bill, amount, date):
-            payment = Payment.objects.create(
-                bill=bill, amount=amount, paid_date=date, type=cls.payment_type
-            )
-            payment.save()
-            return payment
-
         # create a payment type
         cls.payment_type = PaymentType.objects.create(name='Test Payment Type')
 
@@ -37,19 +19,19 @@ class MemberBalanceTest(BillingTestCase):
         cls.item_type1 = BillItemType.objects.create(name='Test Item Type', booking_account='2211')
 
         # create some bills
-        cls.bill1 = create_bill(cls.member1, date(2024, 10, 1), 1200)
-        cls.bill2 = create_bill(cls.member1, date(2024, 11, 1), 1300)
-        cls.bill3 = create_bill(cls.member1, date(2025, 2, 1), 1400)
-        cls.bill4 = create_bill(cls.member2, date(2024, 10, 1), 1500)
-        cls.bill5 = create_bill(cls.member2, date(2024, 11, 1), 1600)
+        cls.bill1 = cls.create_bill(cls.member1, cls.item_type1, date(2024, 10, 1), 1200)
+        cls.bill2 = cls.create_bill(cls.member1, cls.item_type1, date(2024, 11, 1), 1300)
+        cls.bill3 = cls.create_bill(cls.member1, cls.item_type1, date(2025, 2, 1), 1400)
+        cls.bill4 = cls.create_bill(cls.member2, cls.item_type1, date(2024, 10, 1), 1500)
+        cls.bill5 = cls.create_bill(cls.member2, cls.item_type1, date(2024, 11, 1), 1600)
 
         # create some payments
-        create_payment(cls.bill1, 400, date(2024, 10, 15))
-        create_payment(cls.bill1, 800, date(2024, 11, 15))
-        create_payment(cls.bill2, 1500, date(2024, 11, 15))     # overpayment 200
-        create_payment(cls.bill3, 1400, date(2025, 2, 15))
+        cls.create_payment(cls.payment_type, cls.bill1, 400, date(2024, 10, 15))
+        cls.create_payment(cls.payment_type, cls.bill1, 800, date(2024, 11, 15))
+        cls.create_payment(cls.payment_type, cls.bill2, 1500, date(2024, 11, 15))  # overpayment 200
+        cls.create_payment(cls.payment_type, cls.bill3, 1400, date(2025, 2, 15))
         # no payment for bill4, -1500
-        create_payment(cls.bill5, 1500, date(2024, 10, 15))
+        cls.create_payment(cls.payment_type, cls.bill5, 1500, date(2024, 10, 15))
 
     def test_member_balance(self):
         balances = get_memberbalances(date(2024, 12, 31))

--- a/juntagrico_billing/tests/test_memberbalance.py
+++ b/juntagrico_billing/tests/test_memberbalance.py
@@ -1,7 +1,7 @@
 from datetime import date
 from . import BillingTestCase
-from juntagrico_billing.models.bill import Bill, BillItem, BillItemType
-from juntagrico_billing.models.payment import Payment, PaymentType
+from juntagrico_billing.models.bill import BillItemType
+from juntagrico_billing.models.payment import PaymentType
 from juntagrico_billing.util.billing import get_memberbalances
 
 

--- a/juntagrico_billing/util/billing.py
+++ b/juntagrico_billing/util/billing.py
@@ -297,6 +297,7 @@ def export_memberbalance_sheet(request, keydate):
 
     return generate_excel(fields.items(), lines, filename)
 
+
 def get_billing_summary(fromdate, tilldate):
     """
     get a summary of billing for a date range.

--- a/juntagrico_billing/util/billing.py
+++ b/juntagrico_billing/util/billing.py
@@ -305,16 +305,16 @@ def get_billing_summary(fromdate, tilldate):
     """
     bills = Bill.objects.in_daterange(fromdate, tilldate)
 
-    range_billed = bills.aggregate(Sum('items__amount'))['items__amount__sum'] or Decimal('0.0')
+    range_billed = bills.aggregate(Sum('items__amount'))['items__amount__sum'] or 0.0
     
     range_payments_query = Payment.objects.in_daterange(fromdate, tilldate)
-    range_payments = range_payments_query.aggregate(Sum('amount'))['amount__sum'] or Decimal('0.0')
+    range_payments = range_payments_query.aggregate(Sum('amount'))['amount__sum'] or 0.0
     
-    start_billed = Bill.objects.filter(booking_date__lt=fromdate).aggregate(Sum('items__amount'))['items__amount__sum'] or Decimal('0.0')
-    end_billed = Bill.objects.filter(booking_date__lte=tilldate).aggregate(Sum('items__amount'))['items__amount__sum'] or Decimal('0.0')
+    start_billed = Bill.objects.filter(booking_date__lt=fromdate).aggregate(Sum('items__amount'))['items__amount__sum'] or 0.0
+    end_billed = Bill.objects.filter(booking_date__lte=tilldate).aggregate(Sum('items__amount'))['items__amount__sum'] or 0.0
 
-    start_payments = Payment.objects.filter(paid_date__lt=fromdate).aggregate(Sum('amount'))['amount__sum'] or Decimal('0.0')
-    end_payments = Payment.objects.filter(paid_date__lte=tilldate).aggregate(Sum('amount'))['amount__sum'] or Decimal('0.0')
+    start_payments = Payment.objects.filter(paid_date__lt=fromdate).aggregate(Sum('amount'))['amount__sum'] or 0.0
+    end_payments = Payment.objects.filter(paid_date__lte=tilldate).aggregate(Sum('amount'))['amount__sum'] or 0.0
 
     return {
         'range_billed': range_billed,

--- a/juntagrico_billing/util/shares_summary.py
+++ b/juntagrico_billing/util/shares_summary.py
@@ -2,6 +2,7 @@ from juntagrico.entity.share import Share
 from django.db.models import Sum
 from decimal import Decimal
 
+
 def get_shares_summary(start_date, end_date):
     """
     Get a summary of share paid and paid back between start_date and end_date,

--- a/juntagrico_billing/views.py
+++ b/juntagrico_billing/views.py
@@ -316,6 +316,7 @@ def memberbalance_export(request):
 
     return render(request, 'jb/memberbalance_export.html', renderdict)
 
+
 @permission_required('juntagrico.is_book_keeper')
 def accounting_summary(request):
     """
@@ -352,10 +353,11 @@ def accounting_summary(request):
         'fromdate': fromdate,
         'tilldate': tilldate,
         'billing': billing,
-        'shares' : shares
+        'shares': shares
     }
 
     return render(request, "jb/accounting_summary.html", renderdict)
+
 
 @login_required
 def user_bills(request):

--- a/juntagrico_billing/views.py
+++ b/juntagrico_billing/views.py
@@ -77,6 +77,7 @@ def bills_setyear(request):
 
 
 @permission_required('juntagrico.is_book_keeper')
+@require_POST
 def bills_generate(request):
     # generate bills for current business year
     year_name = request.session['bills_businessyear']
@@ -175,14 +176,14 @@ def unpublished_bills(request):
 
 
 @permission_required('juntagrico.is_book_keeper')
+@require_POST
 def bills_publish(request):
     """
     POST handler for publishing bills.
     Called from unpublished_bills view.
     """
-    if request.method == 'POST':
-        selected_ids = request.POST.getlist('_selected')
-        publish_bills(selected_ids)
+    selected_ids = request.POST.getlist('_selected')
+    publish_bills(selected_ids)
 
     return redirect(reverse('jb:unpublished-bills-list'))
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@
 coverage>=7.4.0
 ruff>=0.2.0
 python-bidi<0.5.0
+pre-commit


### PR DESCRIPTION
- fix: in accounting overview: amount is a float field. The default must be a float as well otherwise calculation of `range_balance` or `start_balance` fails if it tries to subtract float from Decimal or vice versa.
- Added tests for the management lists
- require POST on views that perform an action
- Add pre-commit hook to run ruff before commits