### PR TITLE
Fix AttributeError in BillItem.__str__ for subscription items without long_name

### DIFF
--- a/juntagrico_billing/models/bill.py
+++ b/juntagrico_billing/models/bill.py
@@ -214,7 +214,7 @@ class BillItem(JuntagricoBaseModel):
     def __str__(self):
         if self.subscription_part:
             return self.subscription_part.type.long_name or\
-                self.subscription_part.type.size.name
+                self.subscription_part.type.bundle.long_name
         elif self.custom_item_type:
             return ('%s %s' % (self.custom_item_type.name, self.description)).strip()
         else:

--- a/juntagrico_billing/tests/test_bills.py
+++ b/juntagrico_billing/tests/test_bills.py
@@ -312,6 +312,20 @@ class BillCustomItemsTest(BillingTestCase):
         self.assertEqual(1310.0, bill.amount, "amount after recalc")
 
 
+class BillItemSubscriptionPartStrTest(BillingTestCase):
+    def test_str_uses_long_name_if_set(self):
+        item = BillItem(bill=Bill(business_year=self.year), subscription_part=self.part)
+        self.assertEqual(self.part.type.long_name, str(item))
+
+    def test_str_falls_back_to_bundle_long_name_if_long_name_not_set(self):
+        # regression test: BillItem.__str__ used to access the no longer
+        # existing SubscriptionType.size attribute in this fallback branch
+        self.sub_type.long_name = ''
+        self.sub_type.save()
+        item = BillItem(bill=Bill(business_year=self.year), subscription_part=self.part)
+        self.assertEqual(self.part.type.bundle.long_name, str(item))
+
+
 class BillsListTest(BillingTestCase):
     @classmethod
     def setUpTestData(cls):


### PR DESCRIPTION
## Summary
- `SubscriptionType.size` was renamed to `SubscriptionType.bundle` upstream in `juntagrico` (juntagrico/juntagrico#743), but the fallback reference in `BillItem.__str__` (`juntagrico_billing/models/bill.py`) was missed during the migration to juntagrico 2.0, causing `AttributeError: 'SubscriptionType' object has no attribute 'size'`.
- The bug only shows up when `SubscriptionType.long_name` is empty, since that's when the `or` fallback evaluates the broken attribute access — this is why it doesn't reproduce for every bill, only for subscription types without a `long_name` set.
- Fixes the reference to use `type.bundle.long_name` rather than a literal `size` → `bundle` rename, since `SubscriptionBundle.name` was itself later renamed to `SubscriptionBundle.long_name` (juntagrico/juntagrico#275) — `SubscriptionBundle` no longer has a `.name` attribute at all.

## Test plan
- [x] Added regression tests covering both branches of `BillItem.__str__` for subscription-part items (with and without `long_name` set)
- [x] Full test suite passes (69 tests)
- [x] `ruff check --preview juntagrico_billing` passes